### PR TITLE
Add a check that user exists in the database

### DIFF
--- a/controllers/auth-controller.js
+++ b/controllers/auth-controller.js
@@ -125,6 +125,10 @@ exports.isAuth = async (req, res, next) => {
     if (!decodedToken) {
       return next(errorCreator("Invalid jwt token", 400));
     }
+    const foundUser = await UserModel.findById(decodedToken.userId);
+    if (!foundUser) {
+      return next(errorCreator("No user found", 400));
+    }
     req.userId = decodedToken.userId;
     next();
   } catch (err) {


### PR DESCRIPTION
Add a check to the `isAuth` middleware. The additional check ensures that the user belonging to the userId exists in the database. If not, an error is thrown.

Before this check, a token belonging to a deleted user could still be used to manage expenses. This was a bug